### PR TITLE
Add a `distance` config to the `RendererOptions`.

### DIFF
--- a/bin/minecraft-render.js
+++ b/bin/minecraft-render.js
@@ -11,6 +11,7 @@ program
   .usage('<jar> [output]')
   .option('-w, --width [width]', 'width', 1000)
   .option('-t, --height [height]', 'height', 1000)
+  .option('-d, --distance [distance]', 'distance', 20)
   .version(package.version)
   .parse(process.argv);
 
@@ -35,9 +36,12 @@ async function Main() {
   const totalBlocks = blocks.length.toString().padStart(padSize, '0');
 
   const rendererOptions = {
-    height: parseInt(options.height) || 1000,
-    width: parseInt(options.width) || 1000
+    height: parseInt(options.height),
+    width: parseInt(options.width),
+    distance: parseInt(options.distance)
   };
+
+  console.log(rendererOptions);
 
   for await (const block of minecraft.render(blocks, rendererOptions)) {
     const j = (++i).toString().padStart(padSize, '0');

--- a/src/render.ts
+++ b/src/render.ts
@@ -12,12 +12,15 @@ const DEBUG_PLANE = 0;
 export interface RendererOptions {
   width?: number;
   height?: number;
+  distance?: number
 }
 
-export async function prepareRenderer({ width = 1000, height = 1000 }: RendererOptions): Promise<Renderer> {
+export async function prepareRenderer({ width = 1000, height = 1000, distance = 20 }: RendererOptions): Promise<Renderer> {
   const scene = new THREE.Scene();
 
   const canvas: rawCanvas.Canvas = createCanvas(width, height);
+
+  console.log(width, height, distance);
 
   const renderer = new THREE.WebGLRenderer({
     canvas: (canvas as any),
@@ -29,7 +32,6 @@ export async function prepareRenderer({ width = 1000, height = 1000 }: RendererO
   renderer.sortObjects = false;
 
   const aspect = width / height;
-  const distance = 20;
   const camera = new THREE.OrthographicCamera(- distance * aspect, distance * aspect, distance, - distance, 0.01, 20000);
 
   const light = new THREE.DirectionalLight(0xFFFFFF, 1.2);


### PR DESCRIPTION
This adds one feature to the command line options from #3 that my own branch had, a distance option.

This allows control of the distance parameter for the camera, allowing user to decide how zoomed in / how much empty space is around the rendered icon.