### PR TITLE
Quick fix for animated texture blocks

### DIFF
--- a/src/minecraft.ts
+++ b/src/minecraft.ts
@@ -1,6 +1,6 @@
 import { destroyRenderer, prepareRenderer, render, RendererOptions } from "./render";
 import { Jar } from "./utils/jar";
-import type { BlockModel, Renderer } from "./utils/types";
+import type { AnimationMeta, BlockModel, Renderer } from "./utils/types";
 //@ts-ignore
 import * as deepAssign from 'assign-deep';
 
@@ -69,8 +69,23 @@ export class Minecraft {
       throw new Error(`Unable to find texture file: ${path}`)
     }
   }
+  async getTextureMetadata(name: string = ''): Promise<AnimationMeta|false> {
+    name = name ?? '';
+    if (name.startsWith('minecraft:')) {
+      name = name.substring('minecraft:'.length);
+    }
+
+    const path = `assets/minecraft/textures/${name}.png.mcmeta`;
+
+    try {
+      return await this.jar.readJson(path);
+    } catch (e) {
+      return false; 
+    }
+  }
 
   async *render(blocks: BlockModel[], options?: RendererOptions) {
+
     try {
       await this.prepareRenderEnvironment(options);
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -48,7 +48,7 @@ export async function prepareRenderer({ width = 1000, height = 1000 }: RendererO
     scene.add(helper);
   }
 
-  return { scene, renderer, canvas, camera, textureCache: {} };
+  return { scene, renderer, canvas, camera, textureCache: {}, animatedCache: {} };
 }
 
 export async function destroyRenderer(renderer: Renderer) {
@@ -129,24 +129,39 @@ export async function render(minecraft: Minecraft, block: BlockModel): Promise<B
 }
 
 
+
 async function constructTextureMaterial(minecraft: Minecraft, path: string, face: Face, element: Element) {
   const cache = minecraft._renderer!.textureCache;
+  const animatedCache = minecraft._renderer!.animatedCache;
   const image = cache[path] ? cache[path] : (cache[path] = await loadImage(await minecraft.getTextureFile(path)));
+  
+  // Animated texture hack
+  // Texture animation is achieved via filmstrip 
+  // (multiple images, concated one under another) and a .mcmeta file with timing info
+  // We Check for that file, and return the contents or FALSE
+  // if the animation metadata is found, we force height = width,
+  // This fixes the texture mapping
+  // For properly animations, we would need to calculate the number of frames (height / width), then render each one.
+  // and then stitch together (note: interpolation is also a value in the metadata)
+  const isAnimated = animatedCache[path] ? animatedCache[path] : animatedCache[path] = (animatedCache[path] = await minecraft.getTextureMetadata(path));
+  const width = image.width;
+  const height = isAnimated !== false ? width : image.height;
 
-  const canvas = rawCanvas.createCanvas(image.width, image.height);
+  const canvas = rawCanvas.createCanvas(width, height);
   const ctx = canvas.getContext('2d');
 
+  
   ctx.imageSmoothingEnabled = false;
 
   if (face.rotation) {
-    ctx.translate(image.width / 2, image.height / 2);
+    ctx.translate(width / 2, height / 2);
     ctx.rotate(face.rotation * THREE.MathUtils.DEG2RAD);
-    ctx.translate(-image.width / 2, -image.height / 2);
+    ctx.translate(-width / 2, -height / 2);
   }
 
-  const uv = face.uv ?? [0, 0, image.width, image.height];
+  const uv = face.uv ?? [0, 0, width, height];
 
-  ctx.drawImage(image, uv[0], uv[1], uv[2] - uv[0], uv[3] - uv[1], 0, 0, image.width, image.height);
+  ctx.drawImage(image, uv[0], uv[1], uv[2] - uv[0], uv[3] - uv[1], 0, 0, width, height);
 
   const texture = new THREE.Texture(canvas as any);
   texture.magFilter = THREE.NearestFilter;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -65,6 +65,19 @@ export interface Renderer {
   renderer: THREE.WebGLRenderer
   canvas: rawCanvas.Canvas
   camera: THREE.OrthographicCamera
+  textureCache: { [key: string]: any },
+  animatedCache: { [key: string]: AnimationMeta | false }
+}
 
-  textureCache: { [key: string]: any }
+export type AnimationMeta = {
+  
+  interpolate?: boolean, // Generate additional frames between keyframes where frametime > 1
+
+  width?: number, //Custom dimensions for none square textures, unused in vanilla
+  height?: number,
+
+  frametime?: number, // Frame time in game ticks, default is 1
+
+  frames?: (number|{ index: number, time: number})[]
+
 }


### PR DESCRIPTION
**NOTE:** This patch does not create animated textures.

This patch fixes the stretching/texture glitch on blocks that have animated textures.

Animations are handled by a filmstrip image (frames stacked beneath each other) and a `.mcmeta` file for metadata on timing and whether interpolation of the frames between each "real" frame should occur.

So, we check for this file and if it's found, force width and height to be the same for the texture material (afaik in vanilla, all animated textures are square so this lets us just map to the first frame of the filmstrip).

It doesn't give us animated textures, but it's a start, allows us to use the output for non animated needs, and caches the meta data file contents in similar manner to the texture cache.